### PR TITLE
Add FID evaluation to the CIFAR-10 training script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     'einops',
     'numpy',
     'torch',
+    'torch-fidelity',
     'torchvision',
     'wandb'
   ],


### PR DESCRIPTION
This adds FID evaluation with https://github.com/toshas/torch-fidelity to the CIFAR-10 training script, which is off by default. FID evaluation takes ~90 minutes on an Nvidia A6000 if 10,000 samples are drawn. The FID values are logged to wandb.